### PR TITLE
Update AsyncPaymentHandler.php

### DIFF
--- a/src/Handlers/AsyncPaymentHandler.php
+++ b/src/Handlers/AsyncPaymentHandler.php
@@ -78,7 +78,7 @@ class AsyncPaymentHandler implements AsynchronousPaymentHandlerInterface
             $request = new TransactionRequest;
         }
 
-        $finalizePage = $this->checkoutHelper->getReturnUrl('buckaroo.payment.finalize');
+        $finalizePage = ($dataBag->has('finishUrl')) ? $dataBag->get('finishUrl') : $this->checkoutHelper->getReturnUrl('buckaroo.payment.finalize');
 
         if ($buckarooKey != 'RequestToPay') {
             $request->setDescription($this->checkoutHelper->getTranslate('buckaroo.order.paymentDescription', ['orderNumber' => $order->getOrderNumber()]));


### PR DESCRIPTION
@Buckaroo-Rens According my issue i have tested your plugin locally and found the problem in `AsyncPaymentHandler.php`

Something to Note i tested it with the Ideal and Shopware-pwa but now we skip the `'buckaroo.payment.finalize'` route when using an finsishUrl in the request.