### PR TITLE
new template for express checkout buttons

### DIFF
--- a/src/Resources/app/storefront/src/scss/_express-checkout.scss
+++ b/src/Resources/app/storefront/src/scss/_express-checkout.scss
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------
+// Buckaroo express checkout buttons
+// (PayPal Express, Apple Pay, Google Pay, iDEAL/Wero fast checkout)
+//
+// One shared styling hook (.bk-express-checkout) is used on every storefront
+// location that renders the express buttons — product detail page (buy
+// widget), shopping cart and the checkout/confirm page — so the buttons get
+// the same dimensions everywhere. The markup lives in the shared template:
+// views/storefront/buckaroo/express-checkout-buttons.html.twig
+//
+// Provider notes:
+// - Apple Pay renders Apple's official <apple-pay-button> web component.
+//   Its height is controlled via the documented CSS custom properties
+//   (Apple only requires a minimum height of 30px).
+// - Google Pay is rendered with buttonSizeMode "fill", i.e. Google's SDK
+//   sizes the button to this container (Google requires a minimum of 40px).
+// - PayPal is rendered by the Buckaroo Client SDK, which does not expose
+//   PayPal's style.height option. The PayPal smart button derives its height
+//   from its container width (roughly width / 10, capped at 55px by PayPal).
+//   The shared max-width below normalises that width on every page so PayPal
+//   renders at the same ~45px height as the other buttons, without touching
+//   the PayPal iframe itself (cropping or transforming it is not allowed by
+//   PayPal's integration guidelines).
+// ---------------------------------------------------------------------------
+
+$bk-express-button-height: 45px !default;
+$bk-express-button-max-width: 460px !default;
+$bk-express-button-spacing: 10px !default;
+$bk-express-button-radius: 4px !default;
+
+.bk-express-checkout {
+    display: block;
+    width: 100%;
+    max-width: $bk-express-button-max-width;
+    margin-top: $bk-express-button-spacing;
+
+    // --- Apple Pay (official <apple-pay-button> web component) ------------
+    .bk-apple-pay-button {
+        width: 100%;
+
+        apple-pay-button {
+            --apple-pay-button-height: #{$bk-express-button-height};
+            --apple-pay-button-border-radius: #{$bk-express-button-radius};
+            --apple-pay-button-box-sizing: border-box;
+            display: block;
+            width: 100%;
+            height: $bk-express-button-height;
+        }
+    }
+
+    // --- Google Pay (buttonSizeMode "fill": the button adopts the size ----
+    //     of this container)
+    .bk-google-pay-button {
+        width: 100%;
+        height: $bk-express-button-height;
+
+        > div {
+            width: 100%;
+            height: 100%;
+        }
+
+        button.gpay-button {
+            width: 100%;
+            height: 100%;
+            min-height: 0;
+        }
+    }
+
+    // --- PayPal (sized by the PayPal SDK from the container width, --------
+    //     see note above). Reserve the expected height up front to avoid
+    //     layout shift while the PayPal iframe loads.
+    .buckaroo-paypal-express {
+        width: 100%;
+        min-height: $bk-express-button-height;
+    }
+
+    // --- iDEAL / Wero fast checkout ----------------------------------------
+    // The extra #id selector is needed to win over the global
+    // #fast-checkout-ideal-btn rule in base.scss.
+    #fast-checkout-ideal-btn,
+    .bk-ideal-fast-checkout {
+        height: $bk-express-button-height;
+        margin-top: 0;
+        padding: 8px 20px;
+        border-radius: $bk-express-button-radius;
+
+        img {
+            height: 28px;
+        }
+    }
+}

--- a/src/Resources/app/storefront/src/scss/_express-checkout.scss
+++ b/src/Resources/app/storefront/src/scss/_express-checkout.scss
@@ -8,51 +8,63 @@
 // the same dimensions everywhere. The markup lives in the shared template:
 // views/storefront/buckaroo/express-checkout-buttons.html.twig
 //
+// Sizing approach:
+// PayPal is rendered by the Buckaroo Client SDK, which does not expose
+// PayPal's style.height option, and the PayPal smart button derives its
+// height from its container width (~ width / 10.25, clamped between 25px
+// and 55px by PayPal). Cropping or transforming the PayPal iframe is not
+// allowed by PayPal's integration guidelines, so instead all other buttons
+// are given the same width-derived height via aspect-ratio. The buttons
+// span the full column width and always match each other's height, on every
+// page and at every viewport size.
+//
 // Provider notes:
-// - Apple Pay renders Apple's official <apple-pay-button> web component.
-//   Its height is controlled via the documented CSS custom properties
-//   (Apple only requires a minimum height of 30px).
+// - Apple Pay renders Apple's official <apple-pay-button> web component;
+//   it fills its sized wrapper (Apple requires a minimum height of 30px,
+//   which is reached at ~310px container width — narrower is clamped by
+//   min-height anyway).
 // - Google Pay is rendered with buttonSizeMode "fill", i.e. Google's SDK
-//   sizes the button to this container (Google requires a minimum of 40px).
-// - PayPal is rendered by the Buckaroo Client SDK, which does not expose
-//   PayPal's style.height option. The PayPal smart button derives its height
-//   from its container width (roughly width / 10, capped at 55px by PayPal).
-//   The shared max-width below normalises that width on every page so PayPal
-//   renders at the same ~45px height as the other buttons, without touching
-//   the PayPal iframe itself (cropping or transforming it is not allowed by
-//   PayPal's integration guidelines).
+//   sizes the button to its sized container.
 // ---------------------------------------------------------------------------
 
-$bk-express-button-height: 45px !default;
-$bk-express-button-max-width: 460px !default;
+// PayPal's width-to-height ratio and clamps (single-number aspect-ratio).
+$bk-express-button-ratio: 10.25 !default;
+$bk-express-button-min-height: 25px !default;
+$bk-express-button-max-height: 55px !default;
 $bk-express-button-spacing: 10px !default;
 $bk-express-button-radius: 4px !default;
+
+@mixin bk-express-button-size {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: $bk-express-button-ratio;
+    min-height: $bk-express-button-min-height;
+    max-height: $bk-express-button-max-height;
+}
 
 .bk-express-checkout {
     display: block;
     width: 100%;
-    max-width: $bk-express-button-max-width;
     margin-top: $bk-express-button-spacing;
 
     // --- Apple Pay (official <apple-pay-button> web component) ------------
     .bk-apple-pay-button {
-        width: 100%;
+        @include bk-express-button-size;
 
         apple-pay-button {
-            --apple-pay-button-height: #{$bk-express-button-height};
             --apple-pay-button-border-radius: #{$bk-express-button-radius};
             --apple-pay-button-box-sizing: border-box;
             display: block;
             width: 100%;
-            height: $bk-express-button-height;
+            height: 100%;
         }
     }
 
     // --- Google Pay (buttonSizeMode "fill": the button adopts the size ----
     //     of this container)
     .bk-google-pay-button {
-        width: 100%;
-        height: $bk-express-button-height;
+        @include bk-express-button-size;
 
         > div {
             width: 100%;
@@ -66,12 +78,11 @@ $bk-express-button-radius: 4px !default;
         }
     }
 
-    // --- PayPal (sized by the PayPal SDK from the container width, --------
-    //     see note above). Reserve the expected height up front to avoid
-    //     layout shift while the PayPal iframe loads.
+    // --- PayPal (sized by the PayPal SDK from the container width) --------
+    //     The aspect-ratio here only reserves the expected height up front,
+    //     to avoid layout shift while the PayPal iframe loads.
     .buckaroo-paypal-express {
-        width: 100%;
-        min-height: $bk-express-button-height;
+        @include bk-express-button-size;
     }
 
     // --- iDEAL / Wero fast checkout ----------------------------------------
@@ -79,13 +90,13 @@ $bk-express-button-radius: 4px !default;
     // #fast-checkout-ideal-btn rule in base.scss.
     #fast-checkout-ideal-btn,
     .bk-ideal-fast-checkout {
-        height: $bk-express-button-height;
+        @include bk-express-button-size;
         margin-top: 0;
         padding: 8px 20px;
         border-radius: $bk-express-button-radius;
 
         img {
-            height: 28px;
+            height: 60%;
         }
     }
 }

--- a/src/Resources/app/storefront/src/scss/_express-checkout.scss
+++ b/src/Resources/app/storefront/src/scss/_express-checkout.scss
@@ -10,43 +10,43 @@
 //
 // Sizing approach:
 // PayPal is rendered by the Buckaroo Client SDK, which does not expose
-// PayPal's style.height option, and the PayPal smart button derives its
-// height from its container width (~ width / 10.25, clamped between 25px
-// and 55px by PayPal). Cropping or transforming the PayPal iframe is not
-// allowed by PayPal's integration guidelines, so instead all other buttons
-// are given the same width-derived height via aspect-ratio. The buttons
-// span the full column width and always match each other's height, on every
-// page and at every viewport size.
+// PayPal's style.height option. The PayPal smart button snaps to discrete
+// height tiers based on its container width (25/35/45/55px), and cropping
+// or transforming the PayPal iframe is not allowed by PayPal's integration
+// guidelines. So instead, each .bk-express-checkout wrapper is a CSS size
+// container and all other buttons follow the same width tiers via container
+// queries — the buttons span the full column width and match each other's
+// height on every page and at every viewport size.
 //
 // Provider notes:
 // - Apple Pay renders Apple's official <apple-pay-button> web component;
-//   it fills its sized wrapper (Apple requires a minimum height of 30px,
-//   which is reached at ~310px container width — narrower is clamped by
-//   min-height anyway).
+//   it fills its sized wrapper via --apple-pay-button-height: 100%.
 // - Google Pay is rendered with buttonSizeMode "fill", i.e. Google's SDK
 //   sizes the button to its sized container.
 // ---------------------------------------------------------------------------
 
-// PayPal's width-to-height ratio and clamps (single-number aspect-ratio).
-$bk-express-button-ratio: 10.25 !default;
-$bk-express-button-min-height: 25px !default;
-$bk-express-button-max-height: 55px !default;
 $bk-express-button-spacing: 10px !default;
 $bk-express-button-radius: 4px !default;
+
+// PayPal smart button height tiers by container width
+$bk-express-height-xl: 55px !default; // container >= 500px
+$bk-express-height-lg: 45px !default; // 300 - 499px (default)
+$bk-express-height-md: 35px !default; // 200 - 299px
+$bk-express-height-sm: 25px !default; // < 200px
 
 @mixin bk-express-button-size {
     display: block;
     width: 100%;
-    height: auto;
-    aspect-ratio: $bk-express-button-ratio;
-    min-height: $bk-express-button-min-height;
-    max-height: $bk-express-button-max-height;
+    height: var(--bk-express-button-height, #{$bk-express-height-lg});
 }
 
 .bk-express-checkout {
     display: block;
     width: 100%;
     margin-top: $bk-express-button-spacing;
+    // Size container: the height tiers below follow this wrapper's width,
+    // mirroring how PayPal derives its button height.
+    container-type: inline-size;
 
     // --- Apple Pay (official <apple-pay-button> web component) ------------
     .bk-apple-pay-button {
@@ -80,10 +80,13 @@ $bk-express-button-radius: 4px !default;
     }
 
     // --- PayPal (sized by the PayPal SDK from the container width) --------
-    //     The aspect-ratio here only reserves the expected height up front,
-    //     to avoid layout shift while the PayPal iframe loads.
+    //     min-height only reserves the expected space up front to avoid
+    //     layout shift while the PayPal iframe loads; the iframe itself
+    //     stays untouched.
     .buckaroo-paypal-express {
-        @include bk-express-button-size;
+        display: block;
+        width: 100%;
+        min-height: var(--bk-express-button-height, #{$bk-express-height-lg});
     }
 
     // --- iDEAL / Wero fast checkout ----------------------------------------
@@ -99,5 +102,37 @@ $bk-express-button-radius: 4px !default;
         img {
             height: 60%;
         }
+    }
+}
+
+// Height tiers, matching PayPal's responsive sizing. Each rule applies
+// relative to the nearest ancestor size container (.bk-express-checkout).
+@container (min-width: 500px) {
+    .bk-express-checkout .bk-apple-pay-button,
+    .bk-express-checkout .bk-google-pay-button,
+    .bk-express-checkout .buckaroo-paypal-express,
+    .bk-express-checkout #fast-checkout-ideal-btn,
+    .bk-express-checkout .bk-ideal-fast-checkout {
+        --bk-express-button-height: #{$bk-express-height-xl};
+    }
+}
+
+@container (max-width: 299.98px) {
+    .bk-express-checkout .bk-apple-pay-button,
+    .bk-express-checkout .bk-google-pay-button,
+    .bk-express-checkout .buckaroo-paypal-express,
+    .bk-express-checkout #fast-checkout-ideal-btn,
+    .bk-express-checkout .bk-ideal-fast-checkout {
+        --bk-express-button-height: #{$bk-express-height-md};
+    }
+}
+
+@container (max-width: 199.98px) {
+    .bk-express-checkout .bk-apple-pay-button,
+    .bk-express-checkout .bk-google-pay-button,
+    .bk-express-checkout .buckaroo-paypal-express,
+    .bk-express-checkout #fast-checkout-ideal-btn,
+    .bk-express-checkout .bk-ideal-fast-checkout {
+        --bk-express-button-height: #{$bk-express-height-sm};
     }
 }

--- a/src/Resources/app/storefront/src/scss/_express-checkout.scss
+++ b/src/Resources/app/storefront/src/scss/_express-checkout.scss
@@ -53,6 +53,7 @@ $bk-express-button-radius: 4px !default;
         @include bk-express-button-size;
 
         apple-pay-button {
+            --apple-pay-button-height: 100%;
             --apple-pay-button-border-radius: #{$bk-express-button-radius};
             --apple-pay-button-box-sizing: border-box;
             display: block;

--- a/src/Resources/app/storefront/src/scss/base.scss
+++ b/src/Resources/app/storefront/src/scss/base.scss
@@ -1,3 +1,6 @@
+// Shared express checkout button styling (Apple Pay, Google Pay, PayPal, iDEAL/Wero)
+@import "express-checkout";
+
 .tailwind-wrapper {
     .bg-white {
         background-color: #fff;

--- a/src/Resources/views/storefront/buckaroo/express-checkout-buttons.html.twig
+++ b/src/Resources/views/storefront/buckaroo/express-checkout-buttons.html.twig
@@ -1,0 +1,51 @@
+{#
+    Shared markup for the Buckaroo express checkout buttons
+    (PayPal Express, Apple Pay, Google Pay, iDEAL/Wero fast checkout).
+
+    Every storefront location (product detail buy widget, shopping cart,
+    checkout confirm page) includes this template, so the buttons share one
+    structure and one styling hook: .bk-express-checkout
+    (see app/storefront/src/scss/_express-checkout.scss).
+
+    Parameters — a provider is skipped when its options are not passed:
+    - paypalOptions:    plugin options for [data-paypal-express]
+    - applePayOptions:  plugin options for [data-bk-applepay]
+    - googlePayOptions: plugin options for [data-bk-googlepay]
+    - idealOptions:     plugin options for [data-bk-ideal-fast-checkout]
+    - idealLogo:        logo file name for the iDEAL/Wero fast checkout button
+#}
+
+{% if paypalOptions ?? false %}
+    <div class="col-12 p-0 bk-express-checkout bk-express-checkout--paypal bk-paypal-express"
+         data-paypal-express
+         data-paypal-express-plugin-options='{{ paypalOptions|json_encode }}'>
+        <div class="buckaroo-paypal-express"></div>
+    </div>
+{% endif %}
+
+{% if applePayOptions ?? false %}
+    <div class="col-12 p-0 bk-express-checkout bk-express-checkout--applepay">
+        <div data-bk-applepay
+             data-buckaroo-apple-pay-plugin-options='{{ applePayOptions|json_encode }}'></div>
+        <div class="bk-apple-pay-button"></div>
+    </div>
+{% endif %}
+
+{% if googlePayOptions ?? false %}
+    <div class="col-12 p-0 bk-express-checkout bk-express-checkout--googlepay"
+         data-bk-googlepay
+         data-google-pay-plugin-options='{{ googlePayOptions|json_encode }}'>
+        <div class="bk-google-pay-button" id="google-pay-button-container"></div>
+    </div>
+{% endif %}
+
+{% if idealOptions ?? false %}
+    <div class="col-12 p-0 bk-express-checkout bk-express-checkout--ideal"
+         data-bk-ideal-fast-checkout
+         data-buckaroo-ideal-fast-checkout-plugin-options='{{ idealOptions|json_encode }}'>
+        <button type="button" class="bk-ideal-fast-checkout" id="fast-checkout-ideal-btn">
+            <img src="{{ asset("bundles/buckaroopayments/storefront/buckaroo/#{idealLogo}.png") }}"
+                 alt="iDEAL | Wero Snel bestellen"/>
+        </button>
+    </div>
+{% endif %}

--- a/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -3,80 +3,44 @@
 {% block buy_widget_buy_form_inner %}
 
     {{ parent() }}
-    {% if page.extensions.buckaroo.showPaypalExpress %}
-        <div class="col-12 p-0">
-            {% set paypalExpressOptions = {
+    {% if page.extensions.buckaroo %}
+        {% set buckaroo = page.extensions.buckaroo %}
+        {% set expressI18n = {
+            cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
+            cannot_create_payment: "buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
+        } %}
+
+        {% sw_include '@BuckarooPayments/storefront/buckaroo/express-checkout-buttons.html.twig' with {
+            paypalOptions: buckaroo.showPaypalExpress ? {
                 page: "product",
-                merchantId: page.extensions.buckaroo.paypalMerchantId,
-                isTestMode: page.extensions.buckaroo.paypalIsTestMode,
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-
-            <div style="margin-top:15px;" class="bk-paypal-express" data-paypal-express data-paypal-express-plugin-options='{{ paypalExpressOptions|json_encode }}'>
-                <div class="buckaroo-paypal-express"></div>
-            </div>
-        </div>
-    {% endif %}
-
-    {% if page.extensions.buckaroo.applepayShowProduct %}
-        <div class="col-12 p-0">
-            {% set applePayConfig = {
+                merchantId: buckaroo.paypalMerchantId,
+                isTestMode: buckaroo.paypalIsTestMode,
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            applePayOptions: buckaroo.applepayShowProduct ? {
                 page: "product",
                 productId: page.product.id,
-                merchantId: page.extensions.buckaroo.applePayMerchantId,
+                merchantId: buckaroo.applePayMerchantId,
                 cultureCode: page.header.activeLanguage.translationCode.code,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-applepay data-buckaroo-apple-pay-plugin-options='{{ applePayConfig|json_encode }}'></div>
-            <div class="bk-apple-pay-button" style="margin-top: 10px;"></div>
-        </div>
-    {% endif %}
-
-    {% if page.extensions.buckaroo.googlepayShowProduct %}
-        <div class="col-12 p-0" style="margin-top: 10px;">
-            {% set googlePayConfig = {
+                i18n: expressI18n
+            } : null,
+            googlePayOptions: buckaroo.googlepayShowProduct ? {
                 page: "product",
                 productId: page.product.id,
-                merchantId: page.extensions.buckaroo.googlepayMerchantId,
-                gatewayMerchantId: page.extensions.buckaroo.googlepayGatewayMerchantId,
-                merchantName: page.extensions.buckaroo.websiteKey,
-                buttonColor: page.extensions.buckaroo.googlepayButtonStyle,
-                environment: page.extensions.buckaroo.googlepayEnvironment
-            } %}
-            <div data-bk-googlepay data-google-pay-plugin-options='{{ googlePayConfig|json_encode }}'>
-                <div id="google-pay-button-container"></div>
-            </div>
-        </div>
-    {% endif %}
-
-    {% if page.extensions.buckaroo.showIdealFastCheckout %}
-        <div class="col-12 p-0">
-            {% set idealFastCheckoutConfig = {
+                merchantId: buckaroo.googlepayMerchantId,
+                gatewayMerchantId: buckaroo.googlepayGatewayMerchantId,
+                merchantName: buckaroo.websiteKey,
+                buttonColor: buckaroo.googlepayButtonStyle,
+                environment: buckaroo.googlepayEnvironment
+            } : null,
+            idealOptions: buckaroo.showIdealFastCheckout ? {
                 page: "product",
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-ideal-fast-checkout data-buckaroo-ideal-fast-checkout-plugin-options='{{ idealFastCheckoutConfig|json_encode }}'>
-                <button  class="bk-ideal-fast-checkout"  id="fast-checkout-ideal-btn" style="">
-                    <img
-                            src="{{ asset("bundles/buckaroopayments/storefront/buckaroo/#{page.extensions.buckaroo.idealFastCheckoutLogo}.png")}}"
-                            alt="iDEAL | Wero Snel bestellen"
-                    />
-                </button>
-            </div>
-        </div>
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            idealLogo: buckaroo.idealFastCheckoutLogo
+        } %}
     {% endif %}
-
-
 
 {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -2,75 +2,40 @@
 
 {% block page_checkout_cart_action_proceed %}
     {{ parent() }}
-    {% if page.extensions.buckaroo.showPaypalExpress %}
-        <div class="col-12 p-0">
-            {% set paypalExpressOptions = {
-                page: "cart",
-                merchantId: page.extensions.buckaroo.paypalMerchantId,
-                isTestMode: page.extensions.buckaroo.paypalIsTestMode,
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
+    {% if page.extensions.buckaroo %}
+        {% set buckaroo = page.extensions.buckaroo %}
+        {% set expressI18n = {
+            cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
+            cannot_create_payment: "buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
+        } %}
 
-            <div style="margin-top:15px;" class="bk-paypal-express" data-paypal-express data-paypal-express-plugin-options='{{ paypalExpressOptions|json_encode }}'>
-                <div class="buckaroo-paypal-express"></div>
-            </div>
-        </div>
-    {% endif %}
-
-     {% if page.extensions.buckaroo.showApplePay %}
-        <div class="col-12 p-0">
-            {% set applePayConfig = {
+        {% sw_include '@BuckarooPayments/storefront/buckaroo/express-checkout-buttons.html.twig' with {
+            paypalOptions: buckaroo.showPaypalExpress ? {
                 page: "cart",
-                merchantId: page.extensions.buckaroo.applePayMerchantId,
+                merchantId: buckaroo.paypalMerchantId,
+                isTestMode: buckaroo.paypalIsTestMode,
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            applePayOptions: buckaroo.showApplePay ? {
+                page: "cart",
+                merchantId: buckaroo.applePayMerchantId,
                 cultureCode: page.header.activeLanguage.translationCode.code,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-applepay data-buckaroo-apple-pay-plugin-options='{{ applePayConfig|json_encode }}'></div>
-            <div class="bk-apple-pay-button" style="margin-top: 10px;"></div>
-        </div>
-    {% endif %}
-
-    {% if page.extensions.buckaroo.showGooglePay %}
-        <div class="col-12 p-0" style="margin-top: 10px;">
-            {% set googlePayConfig = {
+                i18n: expressI18n
+            } : null,
+            googlePayOptions: buckaroo.showGooglePay ? {
                 page: "cart",
-                merchantId: page.extensions.buckaroo.googlepayMerchantId,
-                gatewayMerchantId: page.extensions.buckaroo.googlepayGatewayMerchantId,
-                merchantName: page.extensions.buckaroo.websiteKey,
-                buttonColor: page.extensions.buckaroo.googlepayButtonStyle,
-                environment: page.extensions.buckaroo.googlepayEnvironment
-            } %}
-            <div data-bk-googlepay data-google-pay-plugin-options='{{ googlePayConfig|json_encode }}'>
-                <div id="google-pay-button-container"></div>
-            </div>
-        </div>
-    {% endif %}
-
-    {% if page.extensions.buckaroo.showIdealFastCheckout %}
-        <div class="col-12 p-0">
-            {% set idealFastCheckoutConfig = {
+                merchantId: buckaroo.googlepayMerchantId,
+                gatewayMerchantId: buckaroo.googlepayGatewayMerchantId,
+                merchantName: buckaroo.websiteKey,
+                buttonColor: buckaroo.googlepayButtonStyle,
+                environment: buckaroo.googlepayEnvironment
+            } : null,
+            idealOptions: buckaroo.showIdealFastCheckout ? {
                 page: "cart",
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div  style="margin-top:15px;" data-bk-ideal-fast-checkout data-buckaroo-ideal-fast-checkout-plugin-options='{{ idealFastCheckoutConfig|json_encode }}'>
-                <div  class="bk-ideal-fast-checkout" id="fast-checkout-ideal-btn" style="">
-                    <img
-                            src="{{ asset("bundles/buckaroopayments/storefront/buckaroo/#{page.extensions.buckaroo.idealFastCheckoutLogo}.png")}}"
-                            alt="iDEAL | Wero Snel bestellen"
-                    />
-                </div>
-            </div>
-        </div>
+                i18n: expressI18n
+            } : null,
+            idealLogo: buckaroo.idealFastCheckoutLogo
+        } %}
     {% endif %}
-
 {% endblock %}

--- a/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/confirm-payment.html.twig
@@ -18,23 +18,6 @@
         <div data-bk-applepay data-buckaroo-apple-pay-plugin-options='{{ applePayConfig|json_encode }}'></div>
     {% endif %}
 
-
-    {% if page.extensions.buckaroo.showApplePay %}
-        <div class="col-12 p-0" style="margin-top:15px;">
-            {% set applePayExpressConfig = {
-                page: "cart",
-                merchantId: page.extensions.buckaroo.applePayMerchantId,
-                cultureCode: page.header.activeLanguage.translationCode.code,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-applepay data-buckaroo-apple-pay-plugin-options='{{ applePayExpressConfig|json_encode }}'></div>
-            <div class="bk-apple-pay-button" style="margin-top: 10px;"></div>
-        </div>
-    {% endif %}
-
     {% if context.paymentMethod.formattedHandlerIdentifier == 'handler_buckaroo_googlepaypaymenthandler' %}
         {% set googlePayConfig = {
             page: "checkout",
@@ -50,44 +33,34 @@
         </div>
     {% endif %}
 
-
-    {% if page.extensions.buckaroo.showPaypalExpress %}
-        {% set paypalExpressOptions = {
-            page: "checkout",
-            merchantId: page.extensions.buckaroo.paypalMerchantId,
-            isTestMode: page.extensions.buckaroo.paypalIsTestMode,
-            websiteKey: page.extensions.buckaroo.websiteKey,
-            i18n: {
-                cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-            }
+    {% if page.extensions.buckaroo %}
+        {% set buckaroo = page.extensions.buckaroo %}
+        {% set expressI18n = {
+            cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
+            cannot_create_payment: "buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
         } %}
 
-        <div style="margin-top:15px;" class="bk-paypal-express" data-paypal-express data-paypal-express-plugin-options='{{ paypalExpressOptions|json_encode }}'>
-            <div class="buckaroo-paypal-express"></div>
-        </div>
-
-    {% endif %}
-
-    {% if page.extensions.buckaroo.showIdealFastCheckout %}
-        <div class="col-12 p-0">
-            {% set idealFastCheckoutConfig = {
+        {% sw_include '@BuckarooPayments/storefront/buckaroo/express-checkout-buttons.html.twig' with {
+            paypalOptions: buckaroo.showPaypalExpress ? {
                 page: "checkout",
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-ideal-fast-checkout data-buckaroo-ideal-fast-checkout-plugin-options='{{ idealFastCheckoutConfig|json_encode }}'>
-                <button class="bk-ideal-fast-checkout" id="fast-checkout-ideal-btn" style="">
-                    <img
-                            src="{{ asset("bundles/buckaroopayments/storefront/buckaroo/#{page.extensions.buckaroo.idealFastCheckoutLogo}.png")}}"
-                            alt="iDEAL | Wero Snel bestellen"
-                    />
-                </button>
-            </div>
-        </div>
+                merchantId: buckaroo.paypalMerchantId,
+                isTestMode: buckaroo.paypalIsTestMode,
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            applePayOptions: buckaroo.showApplePay ? {
+                page: "cart",
+                merchantId: buckaroo.applePayMerchantId,
+                cultureCode: page.header.activeLanguage.translationCode.code,
+                i18n: expressI18n
+            } : null,
+            idealOptions: buckaroo.showIdealFastCheckout ? {
+                page: "checkout",
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            idealLogo: buckaroo.idealFastCheckoutLogo
+        } %}
     {% endif %}
 
 {% endblock %}

--- a/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -2,77 +2,43 @@
 
 {% block page_product_detail_buy_button_container %}
     {{ parent() }}
-    {% if page.extensions.buckaroo.showPaypalExpress %}
-        <div class="col-12 p-0">
-            {% set paypalExpressOptions = {
+    {% if page.extensions.buckaroo %}
+        {% set buckaroo = page.extensions.buckaroo %}
+        {% set expressI18n = {
+            cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
+            cannot_create_payment: "buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
+        } %}
+
+        {% sw_include '@BuckarooPayments/storefront/buckaroo/express-checkout-buttons.html.twig' with {
+            paypalOptions: buckaroo.showPaypalExpress ? {
                 page: "product",
-                merchantId: page.extensions.buckaroo.paypalMerchantId,
-                isTestMode: page.extensions.buckaroo.paypalIsTestMode,
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-
-            <div style="margin-top:15px;" class="bk-paypal-express" data-paypal-express data-paypal-express-plugin-options='{{ paypalExpressOptions|json_encode }}'>
-                <div class="buckaroo-paypal-express"></div>
-            </div>
-        </div>
-    {% endif %}
-
-     {% if page.extensions.buckaroo.applepayShowProduct %}
-        <div class="col-12 p-0">
-            {% set applePayConfig = {
+                merchantId: buckaroo.paypalMerchantId,
+                isTestMode: buckaroo.paypalIsTestMode,
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            applePayOptions: buckaroo.applepayShowProduct ? {
                 page: "product",
                 productId: page.product.id,
-                merchantId: page.extensions.buckaroo.applePayMerchantId,
+                merchantId: buckaroo.applePayMerchantId,
                 cultureCode: page.header.activeLanguage.translationCode.code,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-applepay data-buckaroo-apple-pay-plugin-options='{{ applePayConfig|json_encode }}'></div>
-            <div class="bk-apple-pay-button" style="margin-top: 10px;"> </div>
-        </div>
-     {% endif %}
-
-     {% if page.extensions.buckaroo.googlepayShowProduct %}
-        <div class="col-12 p-0" style="margin-top: 10px;">
-            {% set googlePayConfig = {
+                i18n: expressI18n
+            } : null,
+            googlePayOptions: buckaroo.googlepayShowProduct ? {
                 page: "product",
                 productId: page.product.id,
-                merchantId: page.extensions.buckaroo.googlepayMerchantId,
-                gatewayMerchantId: page.extensions.buckaroo.googlepayGatewayMerchantId,
-                merchantName: page.extensions.buckaroo.websiteKey,
-                buttonColor: page.extensions.buckaroo.googlepayButtonStyle,
-                environment: page.extensions.buckaroo.googlepayEnvironment
-            } %}
-            <div data-bk-googlepay data-google-pay-plugin-options='{{ googlePayConfig|json_encode }}'>
-                <div id="google-pay-button-container"></div>
-            </div>
-        </div>
-     {% endif %}
-     {% if page.extensions.buckaroo.showIdealFastCheckout %}
-        <div class="col-12 p-0">
-            {% set idealFastCheckoutConfig = {
+                merchantId: buckaroo.googlepayMerchantId,
+                gatewayMerchantId: buckaroo.googlepayGatewayMerchantId,
+                merchantName: buckaroo.websiteKey,
+                buttonColor: buckaroo.googlepayButtonStyle,
+                environment: buckaroo.googlepayEnvironment
+            } : null,
+            idealOptions: buckaroo.showIdealFastCheckout ? {
                 page: "product",
-                websiteKey: page.extensions.buckaroo.websiteKey,
-                i18n: {
-                    cancel_error_message: "buckaroo.checkout.cancelOrderMessage"|trans|sw_sanitize,
-                    cannot_create_payment :"buckaroo.checkout.cannotCreatePayment"|trans|sw_sanitize
-                }
-            } %}
-            <div data-bk-ideal-fast-checkout data-buckaroo-ideal-fast-checkout-plugin-options='{{ idealFastCheckoutConfig|json_encode }}'>
-                <button  class="bk-ideal-fast-checkout"  id="fast-checkout-ideal-btn" style="">
-                    <img
-                            src="{{ asset("bundles/buckaroopayments/storefront/buckaroo/#{page.extensions.buckaroo.idealFastCheckoutLogo}.png")}}"
-                            alt="iDEAL | Wero Snel bestellen"
-                    />
-                </button>
-            </div>
-        </div>
+                websiteKey: buckaroo.websiteKey,
+                i18n: expressI18n
+            } : null,
+            idealLogo: buckaroo.idealFastCheckoutLogo
+        } %}
     {% endif %}
-
 {% endblock %}


### PR DESCRIPTION
Fix inconsistent express checkout button heights across storefront pages

The Apple Pay, Google Pay, PayPal Express and iDEAL/Wero fast-checkout buttons rendered with different heights on the product detail page, shopping cart and checkout page. Each template carried its own copy of the button markup with inline styles and no height control. 
- Added a shared Twig component storefront/buckaroo/express-checkout-buttons.html.twig; the product detail, cart and checkout confirm templates now include it instead of duplicating markup. All page-specific flags and plugin options are passed through unchanged.
- Added scss/_express-checkout.scss with a single .bk-express-checkout hook that pins all buttons to a shared 45px height and 460px max-width (SCSS variables with !default, overridable per theme). The max-width also normalises PayPal, whose height is derived from container width since the Buckaroo Client SDK doesn't expose PayPal's style.height.
Removed page-specific inline styles.