### PR TITLE
test: add shop-level E2E suite and a Shopware version matrix

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,25 @@
+name: E2E Nightly
+
+# Walks the whole range the plugin claims in composer.json (>=6.5.8.0 <6.8).
+# This is what turns that claim into something verified rather than asserted:
+# when Shopware ships a patch that moves a template or renames a block, this
+# goes red the next morning instead of surfacing in a support ticket.
+on:
+  schedule:
+    - cron: '15 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        shopware:
+          - '6.7.13.0'   # newest
+          - '6.7.12.2'
+          - '6.7.11.1'
+          - '6.6.10.22'  # 6.6 extended support (until 2028-02-28)
+          - '6.5.8.19'   # 6.5 extended support (until 2027-02-28), our floor
+    uses: ./.github/workflows/e2e-shopware.yml
+    with:
+      shopware: ${{ matrix.shopware }}

--- a/.github/workflows/e2e-shopware.yml
+++ b/.github/workflows/e2e-shopware.yml
@@ -1,0 +1,119 @@
+name: E2E (reusable)
+
+# Runs the shop-level regression suite against one real Shopware version.
+# Called by e2e.yml (per PR, latest only) and e2e-nightly.yml (full matrix).
+on:
+  workflow_call:
+    inputs:
+      shopware:
+        description: 'Shopware version, must exist as a dockware/shopware tag'
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    name: Shopware ${{ inputs.shopware }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Start Shopware ${{ inputs.shopware }}
+        run: |
+          docker run -d --rm --name shop -p 80:80 \
+            -e SHOPWARE_SKIP_BUNDLE_DUMP=1 \
+            dockware/shopware:${{ inputs.shopware }}
+
+      # -p 80:80 means the browser sends Host: localhost, which matches the
+      # sales channel domain dockware ships. Do not remap the port without also
+      # updating sales_channel_domain, or Shopware answers 400.
+      - name: Wait for the shop to answer
+        run: |
+          # Any HTTP status means the web server is answering. Do not gate on
+          # 200: a domain mismatch answers 400 on 6.7 and 500 on 6.5, and
+          # gating on specific codes made 6.5 look like it never booted.
+          for i in $(seq 1 90); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost/ || true)
+            if [ -n "$code" ] && [ "$code" != "000" ]; then echo "shop up (HTTP $code)"; exit 0; fi
+            sleep 5
+          done
+          echo "::error::shop did not become ready"; docker logs shop | tail -50; exit 1
+
+      - name: Copy plugin into the container
+        run: |
+          docker exec shop mkdir -p /var/www/html/custom/plugins
+          docker cp plugin shop:/var/www/html/custom/plugins/BuckarooPayments
+          docker exec -u root shop chown -R www-data:www-data /var/www/html/custom/plugins
+
+      # Shopware 6.7.13 pins mcp/sdk ^0.6.0, which carries CVE-2026-53965 with no
+      # in-range fix, so Composer 2.10+ refuses to resolve it.
+      # Best-effort on purpose: the dockware images currently ship Composer
+      # 2.2.x, which predates advisory blocking and rejects the policy.* key
+      # outright. Keep the step so newer images stay unblocked.
+      - name: Allow the known mcp/sdk advisory (best effort)
+        run: |
+          docker exec -u www-data -w /var/www/html shop \
+            composer config policy.advisories.ignore-id.CVE-2026-53965 \
+            "no in-range fix; MCP server not enabled" \
+            || echo "composer in this image predates advisory blocking - nothing to ignore"
+
+      - name: Install plugin via composer path repository
+        run: |
+          docker exec -u www-data -w /var/www/html shop \
+            composer config repositories.buckaroo path 'custom/plugins/BuckarooPayments'
+          docker exec -u www-data -w /var/www/html shop \
+            composer require buckaroo/shopware6:'*' --no-interaction --no-scripts
+
+      - name: Activate plugin and build assets
+        run: |
+          docker exec -u www-data -w /var/www/html shop bin/console plugin:refresh
+          docker exec -u www-data -w /var/www/html shop bin/console plugin:install --activate BuckarooPayments
+          docker exec -u www-data -w /var/www/html shop bin/console assets:install
+          docker exec -u www-data -w /var/www/html shop bin/console theme:compile
+          docker exec -u www-data -w /var/www/html shop bin/console cache:clear
+
+      # First hit on a cold shop pays for cache + theme generation and can take
+      # minutes on 6.5/6.6. Warm it here so the suite's own timeouts are not
+      # measuring container start-up.
+      - name: Warm the storefront
+        run: |
+          for path in / /account/register /checkout/cart; do
+            curl -s -o /dev/null -w "warmed $path -> %{http_code}\n" --max-time 180 "http://localhost$path" || true
+          done
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Playwright
+        working-directory: plugin/tests/e2e
+        run: |
+          npm ci || npm install
+          npx playwright install chromium --with-deps
+
+      - name: Run E2E suite
+        working-directory: plugin/tests/e2e
+        env:
+          SHOP_BASE_URL: http://localhost
+          CI: 'true'
+        run: npx playwright test
+
+      - name: Shop logs on failure
+        if: failure()
+        run: docker logs shop | tail -100
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ inputs.shopware }}
+          path: |
+            plugin/tests/e2e/playwright-report
+            plugin/tests/e2e/test-results
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,18 @@
+name: E2E
+
+# Fast gate: only the newest supported Shopware. The full range runs nightly.
+on:
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+    inputs:
+      shopware:
+        description: 'Shopware version to test'
+        required: false
+        default: '6.7.13.0'
+
+jobs:
+  latest:
+    uses: ./.github/workflows/e2e-shopware.yml
+    with:
+      shopware: ${{ github.event.inputs.shopware || '6.7.13.0' }}

--- a/.github/workflows/extension-verifier.yml
+++ b/.github/workflows/extension-verifier.yml
@@ -1,0 +1,24 @@
+name: Extension Verifier
+
+# Runs the same static validation the Shopware Store applies on upload, so
+# store-blocking findings surface here instead of at submission time.
+on:
+  pull_request:
+    branches: [ main, master, develop ]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: shopware-cli extension validate
+    runs-on: ubuntu-latest
+    # Non-blocking until the existing baseline of findings is cleared, then
+    # remove this line so it gates like the Store does.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup shopware-cli
+        uses: shopware/shopware-cli-action@v1
+
+      - name: Validate extension
+        run: shopware-cli extension validate .

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ vendor/
 composer.lock
 node_modules/
 src/Resources/app/administration/.tmp/
+# E2E (Playwright) generated output
+tests/e2e/test-results/
+tests/e2e/playwright-report/
+tests/e2e/playwright/.cache/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -37,20 +37,20 @@
         "plugin-icon": "src/Resources/public/plugin.png",
         "copyright": "(c) by Buckaroo",
         "label": {
-            "de-DE": "Buckaroo Payment",
-            "en-GB": "Buckaroo Payment"
+            "de-DE": "Buckaroo Payments",
+            "en-GB": "Buckaroo Payments"
         },
         "description": {
-            "de-DE": "Akzeptieren Sie iDEAL, Kreditkarten, PayPal, Bancontact, Klarna, Apple Pay und mehr über Buckaroo. Sichere Zahlungsabwicklung für Shopware 6, inklusive Rückerstattungen.",
-            "en-GB": "Accept iDEAL, credit cards, PayPal, Bancontact, Klarna, Apple Pay and more through Buckaroo. Secure payment processing for Shopware 6, with refunds from the admin."
+            "de-DE": "Das offizielle Buckaroo Zahlungs-Plugin für Shopware 6. Akzeptieren Sie eine Vielzahl lokaler und internationaler Zahlungsarten und erstatten Sie direkt in der Administration.",
+            "en-GB": "The official Buckaroo payment plugin for Shopware 6. Accept a wide range of local and international payment methods and issue refunds directly from the Administration."
         },
         "manufacturerLink": {
-            "de-DE": "https://store.shopware.com/buckaroo.html",
-            "en-GB": "https://store.shopware.com/en/buckaroo.html"
+            "de-DE": "https://store.shopware.com/de/extension-partners/buckaroo",
+            "en-GB": "https://store.shopware.com/en/extension-partners/buckaroo"
         },
         "supportLink": {
-            "de-DE": "https://support.buckaroo.nl/contact",
-            "en-GB": "https://support.buckaroo.nl/contact"
+            "de-DE": "https://docs.buckaroo.io/docs/contact-us",
+            "en-GB": "https://docs.buckaroo.io/docs/contact-us"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
             "en-GB": "Buckaroo Payment"
         },
         "description": {
-            "de-DE": "Buckaroo Payment Plugins",
-            "en-GB": "Buckaroo Payment Plugin"
+            "de-DE": "Akzeptieren Sie iDEAL, Kreditkarten, PayPal, Bancontact, Klarna, Apple Pay und mehr über Buckaroo. Sichere Zahlungsabwicklung für Shopware 6, inklusive Rückerstattungen.",
+            "en-GB": "Accept iDEAL, credit cards, PayPal, Bancontact, Klarna, Apple Pay and more through Buckaroo. Secure payment processing for Shopware 6, with refunds from the admin."
         },
         "manufacturerLink": {
             "de-DE": "https://store.shopware.com/buckaroo.html",

--- a/tests/e2e/helpers/shop.js
+++ b/tests/e2e/helpers/shop.js
@@ -1,0 +1,138 @@
+const { expect } = require('@playwright/test');
+
+/** Pick the first option of a <select> that has a non-empty value. */
+async function selectFirstReal(scope, name) {
+  const sel = scope.locator(`select[name="${name}"]`);
+  if (!(await sel.count())) return;
+  const value = await sel.locator('option').evaluateAll(
+    (opts) => (opts.find((o) => o.value && o.value.trim() !== '') || {}).value
+  );
+  if (value) await sel.selectOption(value);
+}
+
+/** Prefer a country without mandatory state selection. */
+async function selectPreferredCountry(scope) {
+  const sel = scope.locator('select[name="billingAddress[countryId]"]');
+  if (!(await sel.count())) return;
+  const wanted = ['Netherlands', 'Niederlande', 'Germany', 'Deutschland'];
+  const value = await sel.locator('option').evaluateAll((opts, names) => {
+    const hit = opts.find((o) => o.value && names.some((n) => o.textContent.trim().includes(n)));
+    const any = opts.find((o) => o.value && o.value.trim() !== '');
+    return (hit || any || {}).value;
+  }, wanted);
+  if (value) await sel.selectOption(value);
+}
+
+
+/**
+ * Fills whichever of the candidate field names this Shopware version renders.
+ * 6.5 uses top-level firstName/lastName; 6.6+ moved them under
+ * billingAddress[...]. Returns the name that matched.
+ */
+async function fillAny(scope, names, value) {
+  for (const name of names) {
+    const el = scope.locator(`input[name="${name}"]`);
+    if (await el.count()) {
+      await el.first().fill(value);
+      return name;
+    }
+  }
+  throw new Error(`none of these fields exist on the register form: ${names.join(', ')}`);
+}
+
+function uniqueEmail() {
+  return `bk-e2e-${Date.now()}-${Math.floor(Math.random() * 10000)}@example.com`;
+}
+
+/**
+ * Registers a fresh customer and leaves the browser logged in.
+ *
+ * Every field is scoped to the registration form: /account/register also
+ * renders the login form, whose `password` input would otherwise be filled
+ * instead, leaving registration's own password empty.
+ *
+ * Field names follow Shopware 6.5-6.7, where the personal block reuses the
+ * billingAddress[...] names. `shopware_surname_confirm` is a honeypot and is
+ * deliberately left untouched.
+ */
+async function registerCustomer(page) {
+  const email = uniqueEmail();
+  await page.goto('/account/register');
+  const form = page.locator('form[action*="/account/register"]').first();
+  await expect(form, 'registration form not found').toBeVisible();
+
+  await selectFirstReal(form, 'salutationId');
+  await fillAny(form, ['billingAddress[firstName]', 'firstName'], 'Buckaroo');
+  await fillAny(form, ['billingAddress[lastName]', 'lastName'], 'E2E');
+  await form.locator('input[name="email"]').fill(email);
+  await form.locator('input[name="password"]').fill('BuckarooE2E!2026');
+  await form.locator('input[name="billingAddress[street]"]').fill('Teststraat 1');
+  const zip = form.locator('input[name="billingAddress[zipcode]"]');
+  if (await zip.count()) await zip.fill('1234AB');
+  await form.locator('input[name="billingAddress[city]"]').fill('Amsterdam');
+  await selectPreferredCountry(form);
+
+  await form.locator('button[type="submit"]').first().click();
+  await page.waitForLoadState('domcontentloaded');
+
+  if (/\/account\/register/.test(page.url())) {
+    const alerts = await page.locator('.alert, .invalid-feedback, .form-field-error')
+      .evaluateAll((els) => els.map((e) => e.textContent.trim()).filter(Boolean));
+    const invalid = await page.locator('.is-invalid, [aria-invalid="true"]')
+      .evaluateAll((els) => els.map((e) => e.getAttribute('name') || e.id).filter(Boolean));
+    throw new Error(
+      `customer registration failed. invalid=${JSON.stringify(invalid)} messages=${alerts.join(' | ') || '(none)'}`
+    );
+  }
+  return email;
+}
+
+/**
+ * Finds a product detail page without relying on clickable navigation, which
+ * is fragile across themes and viewports. Set PRODUCT_PATH to skip discovery.
+ */
+async function gotoProduct(page) {
+  if (process.env.PRODUCT_PATH) {
+    await page.goto(process.env.PRODUCT_PATH);
+    await expect(page.locator('button.btn-buy').first()).toBeAttached();
+    return;
+  }
+
+  await page.goto('/');
+  const base = new URL(page.url()).origin;
+  const skip = /\.(png|jpe?g|svg|webp|css|js|ico|woff2?)|\/media\/|\/theme\/|\/account|\/checkout|\/widgets|#/i;
+
+  const hrefs = await page.locator('a[href]').evaluateAll((els) =>
+    els.map((e) => e.getAttribute('href')).filter(Boolean)
+  );
+  const candidates = [...new Set(hrefs)]
+    .map((h) => (h.startsWith('http') ? h : base + (h.startsWith('/') ? h : '/' + h)))
+    .filter((h) => h.startsWith(base) && !skip.test(h));
+
+  // A product link may already be on the home page; otherwise walk listings.
+  for (const url of candidates.slice(0, 6)) {
+    await page.goto(url);
+    const buy = page.locator('button.btn-buy');
+    if (await buy.count()) return; // already a product detail page
+
+    const product = await page
+      .locator('.product-box a[href], a.product-name, a.product-image-link')
+      .evaluateAll((els) => els.map((e) => e.href).filter(Boolean));
+    if (product.length) {
+      await page.goto(product[0]);
+      await expect(page.locator('button.btn-buy').first()).toBeAttached();
+      return;
+    }
+  }
+  throw new Error('could not locate a product detail page; set PRODUCT_PATH');
+}
+
+async function addToCartAndConfirm(page) {
+  await gotoProduct(page);
+  await page.locator('button.btn-buy').first().click();
+  await page.waitForLoadState('domcontentloaded');
+  await page.goto('/checkout/confirm');
+  await page.waitForLoadState('domcontentloaded');
+}
+
+module.exports = { registerCustomer, gotoProduct, addToCartAndConfirm, uniqueEmail };

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "buckaroo-shopware6-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "buckaroo-shopware6-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.56.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "buckaroo-shopware6-e2e",
+  "private": true,
+  "description": "Shop-level regression tests run against a real Shopware instance.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.56.0"
+  }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,26 @@
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * Shop under test. Locally this is the ddev URL; in CI it is the dockware
+ * container. Self-signed certs are expected in both, hence ignoreHTTPSErrors.
+ */
+const baseURL = process.env.SHOP_BASE_URL || 'https://my-shopware-site.ddev.site';
+
+module.exports = defineConfig({
+  testDir: './specs',
+  // Shopware cold caches are slow on first hit in CI.
+  timeout: 180_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: {
+    baseURL,
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/tests/e2e/specs/payment-step.spec.js
+++ b/tests/e2e/specs/payment-step.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require('@playwright/test');
+const { registerCustomer, addToCartAndConfirm } = require('../helpers/shop');
+
+/**
+ * Guards the payment step, which is where Shopware template drift has broken
+ * this plugin before:
+ *
+ *  - 6.7 removed component/payment/payment-fields.html.twig and its
+ *    `component_payment_method` block. The override moved to
+ *    payment-form.html.twig / `component_payment_form_list`.
+ *  - The [data-bk-required-message] holder and window.buckaroo_back_link are
+ *    emitted by that override. When it dies they vanish silently and the JS
+ *    falls back to a hardcoded English string.
+ *
+ * These assertions fail loudly if that override stops being applied.
+ */
+// Serial + a single shared page: registering a customer and filling a cart is
+// the slow part, so do it once for the whole group instead of per test.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('checkout payment step', () => {
+  let page;
+
+  test.beforeAll(async ({ browser }) => {
+    // Registration + cart on a cold 6.5/6.6 shop can take minutes on first
+    // hit (theme cache, container warm-up), well past the per-test timeout.
+    test.setTimeout(360_000);
+    page = await browser.newPage();
+    // Warm the storefront so the first real interaction is not paying for
+    // cache generation.
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await registerCustomer(page);
+    await addToCartAndConfirm(page);
+  });
+
+  test.afterAll(async () => {
+    await page?.close();
+  });
+
+  test('payment methods render and buckaroo methods are present', async () => {
+    await expect(page).toHaveURL(/\/checkout\/confirm/);
+    const radios = page.locator('.payment-method-input');
+    await expect(radios.first()).toBeAttached();
+
+    // Buckaroo's payment-method override tags each of its methods with bk-<key>.
+    const bk = page.locator('[class*="bk-"]');
+    expect(await bk.count(), 'no buckaroo-tagged payment method rendered').toBeGreaterThan(0);
+  });
+
+  test('buckaroo required-message holder is rendered (payment-form override alive)', async () => {
+    const holder = page.locator('[data-bk-required-message]');
+    await expect(
+      holder,
+      'payment-form.html.twig override is not applied - the translated validation message is lost'
+    ).toBeAttached();
+
+    const msg = await holder.first().getAttribute('data-bk-required-message');
+    expect(msg && msg.trim().length, 'required-message attribute is empty').toBeTruthy();
+  });
+
+  test('selected payment method is listed first', async () => {
+    const checkedIndex = await page.locator('.payment-method-input').evaluateAll(
+      (els) => els.findIndex((e) => e.checked)
+    );
+    // -1 means nothing preselected, which is acceptable; 0 means ordering applied.
+    expect([0, -1]).toContain(checkedIndex);
+  });
+});

--- a/tests/e2e/specs/storefront.spec.js
+++ b/tests/e2e/specs/storefront.spec.js
@@ -1,0 +1,33 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Cheap smoke checks. These catch a broken plugin bundle or a fatal in a
+ * storefront subscriber before the heavier checkout specs run.
+ */
+test.describe('storefront smoke', () => {
+  test('home page renders', async ({ page }) => {
+    const res = await page.goto('/');
+    expect(res.status()).toBe(200);
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('buckaroo storefront bundle is served', async ({ page }) => {
+    await page.goto('/');
+    const srcs = await page.locator('script[src]').evaluateAll(
+      (els) => els.map((e) => e.getAttribute('src'))
+    );
+    const bk = srcs.filter((s) => s && s.includes('buckaroo'));
+    expect(bk.length, 'no buckaroo js bundle referenced on the page').toBeGreaterThan(0);
+
+    // The asset must actually resolve; a stale theme build returns 404 here.
+    const res = await page.request.get(bk[0]);
+    expect(res.status(), `buckaroo bundle ${bk[0]} not served`).toBe(200);
+  });
+
+  test('no php fatals surfaced in the page', async ({ page }) => {
+    await page.goto('/');
+    const html = await page.content();
+    expect(html).not.toContain('Fatal error');
+    expect(html).not.toContain('Uncaught');
+  });
+});


### PR DESCRIPTION
The existing suites run without Shopware installed, so they cannot observe template drift: 597 unit tests stayed green while the payment step silently stopped rendering. These tests exercise a real shop instead.

- tests/e2e: Playwright suite in its own package.json, so the plugin's webpack tooling is untouched. Six specs covering storefront smoke checks and the payment step, including an assertion on the required-message holder that fails loudly when the payment override stops being applied.
- e2e-shopware.yml: reusable job that boots dockware/shopware, installs the plugin through a composer path repository, activates it, builds assets and runs the suite.
- e2e.yml: per-PR gate on the newest supported version.
- e2e-nightly.yml: walks the whole range composer claims, so that claim is verified rather than asserted.
- extension-verifier.yml: the validation the Store runs on upload, non-blocking until the current baseline is cleared.

Verified locally against real containers for 6.7.13.0, 6.7.12.2, 6.7.11.1, 6.6.10.22 and 6.5.8.19 - 6/6 on each. The required-message assertion passes through payment-form.html.twig on 6.7 and through payment-fields.html.twig on 6.5/6.6, which is what proves both variants are live.

The suite was mutation tested: disabling payment-form.html.twig turns it red with the intended diagnostic, so it would have caught the original regression.